### PR TITLE
Handle static thresholds and dynamic metric names

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 This repo will be a standalone Go application which will allow users to query their Dynatrace environments and compare the performance of current code deployments to previous ones.
 
-**Current State** - This will receive the timestamps of the most recent Dynatrace Deployment Events and compare the Response Time and Error Count of those two deployments to look for regressions.
-
 # Usage
 ## Requirements
 This app requires the following variables to be set in the **docker_env** file:
@@ -18,7 +16,7 @@ First, you will need to build the docker image. To do so
 A clean way to run this in Windows is
 
 ```
-docker ps -a -q -f name=go-dyna-perf-signature | % { docker stop $_ }; docker ps -a -q -f name=go-dyna-perf-signature | % { docker rm $_ }; docker run -expose -p 8080:8080 --name go-dyna-perf-signature --env-file ./docker_env go-dyna-perf-signature
+docker ps -a -q -f name=go-dyna-perf-signature | % { docker stop $_; docker rm $_ }; docker run -expose -p 8080:8080 --name go-dyna-perf-signature --env-file ./docker_env go-dyna-perf-signature
 ```
 
 ## Running Locally via Go
@@ -27,20 +25,26 @@ You can test this locally by simply calling `go run .`
 ## Interacting with the API
 The required parameters on the POST are:
 * **APIToken** - Your Dynatrace API token which has the permission `Access problem and event feed, metrics, and topology`
-* **MetricIDs** - A comma-delimited array of the metrics you'd like to compare, which can be found from the `Environment API v2` -> `Metrics` -> `GET /metrics/descriptors` API.
-  * **Important** - This is not actually implemented at this point. Unfortunately, `["builtin:service.response.time:(avg)","builtin:service.errors.total.rate:(avg)"]` has to be passed through the curl command and it's the only valid operator. This will be fixed soon.
+* **Metrics** - A comma-delimited array of the metrics you'd like to inspect. 
+  * **ID** - The ID of the metric - The list of metric IDs can be found from the `Environment API v2` -> `Metrics` -> `GET /metrics/descriptors` API.
+    * `builtin:service.response.time:(avg)`
+  * (Optional) **ValidationMethod** - The type of validation you'd like to perform. This is currently limited to `static`. If no value, the default is the comparison model using the most recent and last deployments.
+    * `static`
+  * (Optional) **StaticThreshold** - If you chose the ValidationMethod `static`, you will need to provide the threshold value here. If you do not, the value will default to 0.00.
+    * `1.25`
 * **ServiceID** - The ID of the Service which you'd like to inspect. This can be found in the UI if you are looking at a Service and pull from its url `id=SERVICE-...`
+  * `SERVICE-5D4E743B2BF0CCF5`
 
 ### Example
 From another terminal, you can make requests to the app via a curl like this one:
 
 ```
-curl -v -XPOST -d '{"APIToken":"S2pMHW_FSlma-PPJIj3l5","Metrics":[{"ID":"builtin:service.response.time:(avg)"},{"ID":"builtin:service.errors.total.rate:(avg)"}],"ServiceID":"SERVICE-5D4E743B2BF0CCF5"}' localhost:8080/performanceSignature
+curl -v -XPOST -d '{"APIToken":"S2pMHW_FSlma-PPJIj3l5","Metrics":[{"ID":"builtin:service.response.time:(avg)"},{"ID":"builtin:service.errors.total.rate:(avg)","StaticThreshold":1.0,"ValidationMethod":"static"}],"ServiceID":"SERVICE-5D4E743B2BF0CCF5"}' localhost:8080/performanceSignature
 ```
 
 ## Development Building One-Liner
 ```
-docker ps -a -q -f name=go-dyna-perf-signature | % { docker stop $_ }; docker build -t barrebre/go-dyna-perf-signature:latest .; docker run -expose -p 8080:8080 --name go-dyna-perf-signature --env-file ./docker_env barrebre/go-dyna-perf-signature
+docker ps -a -q -f name=go-dyna-perf-signature | % { docker stop $_ }; docker ps -a -q -f name=go-dyna-perf-signature | % { docker rm $_ }; docker run -expose -p 8080:8080 --name go-dyna-perf-signature --env-file ./docker_env go-dyna-perf-signature
 ```
 
 # Todo

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ curl -v -XPOST -d '{"APIToken":"S2pMHW_FSlma-PPJIj3l5","Metrics":[{"ID":"builtin
 
 ## Development Building One-Liner
 ```
-docker build -t barrebre/go-dyna-perf-signature:latest .; docker ps -a -q -f name=go-dyna-perf-signature | % { docker stop $_ }; docker ps -a -q -f name=go-dyna-perf-signature | % { docker rm $_ }; docker run -expose -p 8080:8080 --name go-dyna-perf-signature --env-file ./docker_env go-dyna-perf-signature
+docker ps -a -q -f name=go-dyna-perf-signature | % { docker stop $_ }; docker build -t barrebre/go-dyna-perf-signature:latest .; docker run -expose -p 8080:8080 --name go-dyna-perf-signature --env-file ./docker_env barrebre/go-dyna-perf-signature
 ```
 
 # Todo

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The required parameters on the POST are:
 From another terminal, you can make requests to the app via a curl like this one:
 
 ```
-curl -v -XPOST -d '{"APIToken":"S2pMHW_FSlma-PPJIj3l5","MetricIDs":["builtin:service.response.time:(avg)","builtin:service.errors.total.rate:(avg)"],"ServiceID":"SERVICE-5D4E743B2BF0CCF5"}' localhost:8080/performanceSignature
+curl -v -XPOST -d '{"APIToken":"S2pMHW_FSlma-PPJIj3l5","Metrics":[{"ID":"builtin:service.response.time:(avg)"},{"ID":"builtin:service.errors.total.rate:(avg)"}],"ServiceID":"SERVICE-5D4E743B2BF0CCF5"}' localhost:8080/performanceSignature
 ```
 
 ## Development Building One-Liner

--- a/datatypes/config.go
+++ b/datatypes/config.go
@@ -1,0 +1,7 @@
+package datatypes
+
+// Config contains the config necessary for the app to run
+type Config struct {
+	Env    string
+	Server string
+}

--- a/datatypes/datatypes.go
+++ b/datatypes/datatypes.go
@@ -1,78 +1,8 @@
 package datatypes
 
-// Config is a set of config for the app
-type Config struct {
-	Env    string
-	Server string
-}
-
-// DeploymentEvents is a collection of Deployment Events
-type DeploymentEvents struct {
-	Events []DeploymentEvent `json:"events"`
-}
-
-// DeploymentEvent defines the data needed from a Dt Deployment Event
-type DeploymentEvent struct {
-	StartTime         int64  `json:"startTime"`
-	EndTime           int64  `json:"endTime"`
-	DeploymentName    string `json:"deploymentName"`
-	DeploymentVersion string `json:"deploymentVersion"`
-}
-
-// DynatraceMetricsResponse defines what we receive from the Dt Metrics v2 API
-type DynatraceMetricsResponse struct {
-	TotalCount  int     `json:"totalCount"`
-	NextPageKey string  `json:"nextPageKey"`
-	Metrics     Metrics `json:"metrics"`
-}
-
-// Both of the following unique definitions could probably be updated to some map syntax
-
-// BuiltinServiceResponseTime has to be defined for some reason
-type BuiltinServiceResponseTime struct {
-	MetricValues []MetricValues `json:"values"`
-}
-
-// BuiltinServiceErrorsTotalRate has to be defined for some reason
-type BuiltinServiceErrorsTotalRate struct {
-	MetricValues []MetricValues `json:"values"`
-}
-
-// ComparisonMetrics has a current and previous set of metrics to compare
-type ComparisonMetrics struct {
-	CurrentMetrics  Metrics
-	PreviousMetrics Metrics
-}
-
-// Metric defines a Dynatrace Service we'd like to investigate and how we'd like to validate it
-type Metric struct {
-	ID              string
-	StaticThreshold int64
-	Validation      string
-}
-
-// MetricValues defines what we receive for each metric
-type MetricValues struct {
-	Dimensions []string `json:"dimensions"`
-	Timestamp  int64    `json:"timestamp"`
-	Value      float64  `json:"value"`
-}
-
-// Metrics lists the metrics options we can currently use
-type Metrics struct {
-	BuiltinServiceResponseTime    BuiltinServiceResponseTime    `json:"builtin:service.response.time:avg"`
-	BuiltinServiceErrorsTotalRate BuiltinServiceErrorsTotalRate `json:"builtin:service.errors.total.rate:avg"`
-}
-
 // PerformanceSignature is a struct defining all of the parameters we need to calculate a performance signature
 type PerformanceSignature struct {
 	APIToken  string
 	Metrics   []Metric
 	ServiceID string
-}
-
-// Timestamps represents a start and end time for Deployment events
-type Timestamps struct {
-	StartTime int64
-	EndTime   int64
 }

--- a/datatypes/datatypes.go
+++ b/datatypes/datatypes.go
@@ -1,5 +1,12 @@
 package datatypes
 
+// Metric defines a Dynatrace Service we'd like to investigate and how we'd like to validate it
+type Metric struct {
+	ID               string
+	StaticThreshold  float64
+	ValidationMethod string
+}
+
 // PerformanceSignature is a struct defining all of the parameters we need to calculate a performance signature
 type PerformanceSignature struct {
 	APIToken  string

--- a/datatypes/datatypes.go
+++ b/datatypes/datatypes.go
@@ -26,13 +26,6 @@ type DynatraceMetricsResponse struct {
 	Metrics     Metrics `json:"metrics"`
 }
 
-// MetricValues defines what we receive for each metric
-type MetricValues struct {
-	Dimensions []string `json:"dimensions"`
-	Timestamp  int64    `json:"timestamp"`
-	Value      float64  `json:"value"`
-}
-
 // Both of the following unique definitions could probably be updated to some map syntax
 
 // BuiltinServiceResponseTime has to be defined for some reason
@@ -45,22 +38,36 @@ type BuiltinServiceErrorsTotalRate struct {
 	MetricValues []MetricValues `json:"values"`
 }
 
-// Metrics lists the metrics options we can currently use
-type Metrics struct {
-	BuiltinServiceResponseTime    BuiltinServiceResponseTime    `json:"builtin:service.response.time:avg"`
-	BuiltinServiceErrorsTotalRate BuiltinServiceErrorsTotalRate `json:"builtin:service.errors.total.rate:avg"`
-}
-
 // ComparisonMetrics has a current and previous set of metrics to compare
 type ComparisonMetrics struct {
 	CurrentMetrics  Metrics
 	PreviousMetrics Metrics
 }
 
+// Metric defines a Dynatrace Service we'd like to investigate and how we'd like to validate it
+type Metric struct {
+	ID              string
+	StaticThreshold int64
+	Validation      string
+}
+
+// MetricValues defines what we receive for each metric
+type MetricValues struct {
+	Dimensions []string `json:"dimensions"`
+	Timestamp  int64    `json:"timestamp"`
+	Value      float64  `json:"value"`
+}
+
+// Metrics lists the metrics options we can currently use
+type Metrics struct {
+	BuiltinServiceResponseTime    BuiltinServiceResponseTime    `json:"builtin:service.response.time:avg"`
+	BuiltinServiceErrorsTotalRate BuiltinServiceErrorsTotalRate `json:"builtin:service.errors.total.rate:avg"`
+}
+
 // PerformanceSignature is a struct defining all of the parameters we need to calculate a performance signature
 type PerformanceSignature struct {
 	APIToken  string
-	MetricIDs []string
+	Metrics   []Metric
 	ServiceID string
 }
 

--- a/datatypes/deployments.go
+++ b/datatypes/deployments.go
@@ -1,0 +1,20 @@
+package datatypes
+
+// DeploymentEvent defines the data needed from a Dt Deployment Event
+type DeploymentEvent struct {
+	StartTime         int64  `json:"startTime"`
+	EndTime           int64  `json:"endTime"`
+	DeploymentName    string `json:"deploymentName"`
+	DeploymentVersion string `json:"deploymentVersion"`
+}
+
+// DeploymentEvents is a collection of Deployment Events
+type DeploymentEvents struct {
+	Events []DeploymentEvent `json:"events"`
+}
+
+// Timestamps represents a start and end time for Deployment events
+type Timestamps struct {
+	StartTime int64
+	EndTime   int64
+}

--- a/datatypes/metrics.go
+++ b/datatypes/metrics.go
@@ -1,0 +1,46 @@
+package datatypes
+
+// Both of the following unique definitions could probably be updated to some map syntax
+
+// BuiltinServiceResponseTime has to be defined for some reason
+type BuiltinServiceResponseTime struct {
+	MetricValues []MetricValues `json:"values"`
+}
+
+// BuiltinServiceErrorsTotalRate has to be defined for some reason
+type BuiltinServiceErrorsTotalRate struct {
+	MetricValues []MetricValues `json:"values"`
+}
+
+// ComparisonMetrics has a current and previous set of metrics to compare
+type ComparisonMetrics struct {
+	CurrentMetrics  Metrics
+	PreviousMetrics Metrics
+}
+
+// DynatraceMetricsResponse defines what we receive from the Dt Metrics v2 API
+type DynatraceMetricsResponse struct {
+	TotalCount  int    `json:"totalCount"`
+	NextPageKey string `json:"nextPageKey"`
+	Metrics     Metric `json:"metrics"`
+}
+
+// Metric defines a Dynatrace Service we'd like to investigate and how we'd like to validate it
+type Metric struct {
+	ID              string
+	StaticThreshold int64
+	Validation      string
+}
+
+// Metrics lists the metrics options we can currently use
+type Metrics struct {
+	BuiltinServiceResponseTime    BuiltinServiceResponseTime    `json:"builtin:service.response.time:avg"`
+	BuiltinServiceErrorsTotalRate BuiltinServiceErrorsTotalRate `json:"builtin:service.errors.total.rate:avg"`
+}
+
+// MetricValues defines what we receive for each metric
+type MetricValues struct {
+	Dimensions []string `json:"dimensions"`
+	Timestamp  int64    `json:"timestamp"`
+	Value      float64  `json:"value"`
+}

--- a/datatypes/metrics.go
+++ b/datatypes/metrics.go
@@ -1,41 +1,19 @@
 package datatypes
 
-// Both of the following unique definitions could probably be updated to some map syntax
-
-// BuiltinServiceResponseTime has to be defined for some reason
-type BuiltinServiceResponseTime struct {
-	MetricValues []MetricValues `json:"values"`
-}
-
-// BuiltinServiceErrorsTotalRate has to be defined for some reason
-type BuiltinServiceErrorsTotalRate struct {
-	MetricValues []MetricValues `json:"values"`
-}
-
 // ComparisonMetrics has a current and previous set of metrics to compare
 type ComparisonMetrics struct {
-	CurrentMetrics  Metrics
-	PreviousMetrics Metrics
+	CurrentMetrics  DynatraceMetricsResponse
+	PreviousMetrics DynatraceMetricsResponse
 }
 
 // DynatraceMetricsResponse defines what we receive from the Dt Metrics v2 API
 type DynatraceMetricsResponse struct {
-	TotalCount  int     `json:"totalCount"`
-	NextPageKey string  `json:"nextPageKey"`
-	Metrics     Metrics `json:"metrics"`
+	Metrics map[string]MetricValuesArray `json:"metrics"`
 }
 
-// Metric defines a Dynatrace Service we'd like to investigate and how we'd like to validate it
-type Metric struct {
-	ID              string
-	StaticThreshold int64
-	Validation      string
-}
-
-// Metrics lists the metrics options we can currently use
-type Metrics struct {
-	BuiltinServiceResponseTime    BuiltinServiceResponseTime    `json:"builtin:service.response.time:avg"`
-	BuiltinServiceErrorsTotalRate BuiltinServiceErrorsTotalRate `json:"builtin:service.errors.total.rate:avg"`
+// MetricValuesArray - The Dynatrace API always returns an array of timestamps, even though we only need the first value each time
+type MetricValuesArray struct {
+	MetricValues []MetricValues `json:"values"`
 }
 
 // MetricValues defines what we receive for each metric

--- a/datatypes/metrics.go
+++ b/datatypes/metrics.go
@@ -20,9 +20,9 @@ type ComparisonMetrics struct {
 
 // DynatraceMetricsResponse defines what we receive from the Dt Metrics v2 API
 type DynatraceMetricsResponse struct {
-	TotalCount  int    `json:"totalCount"`
-	NextPageKey string `json:"nextPageKey"`
-	Metrics     Metric `json:"metrics"`
+	TotalCount  int     `json:"totalCount"`
+	NextPageKey string  `json:"nextPageKey"`
+	Metrics     Metrics `json:"metrics"`
 }
 
 // Metric defines a Dynatrace Service we'd like to investigate and how we'd like to validate it

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -7,7 +7,6 @@ import (
 	"math"
 	"net/http"
 	"net/url"
-	"strings"
 	"time"
 
 	"barrebre/goDynaPerfSignature/datatypes"
@@ -19,7 +18,10 @@ import (
 // TODO: Make this work with more than the 2 defined metrics
 func GetMetrics(config datatypes.Config, ps datatypes.PerformanceSignature, ts []datatypes.Timestamps) (datatypes.ComparisonMetrics, error) {
 	// Transform the POSTed metrics into escaped strings
-	metricNames := fmt.Sprintf(strings.Join(ps.MetricIDs, ","))
+	metricNames := ""
+	for _, metric := range ps.Metrics {
+		metricNames += metric.ID + ","
+	}
 	safeMetricNames := url.QueryEscape(metricNames)
 
 	// Build the URL
@@ -76,66 +78,98 @@ func GetMetrics(config datatypes.Config, ps datatypes.PerformanceSignature, ts [
 		return datatypes.ComparisonMetrics{}, fmt.Errorf("There were no Response Time data points found in the current metrics: %v", spew.Sdump(currentMetricsResponse.Metrics))
 	}
 
+	var metrics = datatypes.ComparisonMetrics{
+		CurrentMetrics: currentMetricsResponse.Metrics,
+	}
+
 	// Get the second set of metrics
-	// Build the URL
-	if config.Env == "" {
-		url = fmt.Sprintf("https://%v/api/v2/metrics/series/%v?resolution=Inf&from=%v&to=%v&scope=entity(%v)", config.Server, safeMetricNames, ts[1].StartTime, ts[1].EndTime, ps.ServiceID)
-	} else {
-		url = fmt.Sprintf("https://%v/e/%v/api/v2/metrics/series/%v?resolution=Inf&from=%v&to=%v&scope=entity(%v)", config.Server, config.Env, safeMetricNames, ts[1].StartTime, ts[1].EndTime, ps.ServiceID)
-	}
-	// fmt.Printf("Made URL: %v\n", url)
+	if len(ts) == 2 {
+		// Build the URL
+		if config.Env == "" {
+			url = fmt.Sprintf("https://%v/api/v2/metrics/series/%v?resolution=Inf&from=%v&to=%v&scope=entity(%v)", config.Server, safeMetricNames, ts[1].StartTime, ts[1].EndTime, ps.ServiceID)
+		} else {
+			url = fmt.Sprintf("https://%v/e/%v/api/v2/metrics/series/%v?resolution=Inf&from=%v&to=%v&scope=entity(%v)", config.Server, config.Env, safeMetricNames, ts[1].StartTime, ts[1].EndTime, ps.ServiceID)
+		}
+		// fmt.Printf("Made URL: %v\n", url)
 
-	// Build the request object
-	req, err = http.NewRequest("GET", url, nil)
-	if err != nil {
-		fmt.Printf("Error creating request handler: %v", err)
-		return datatypes.ComparisonMetrics{}, err
-	}
+		// Build the request object
+		req, err = http.NewRequest("GET", url, nil)
+		if err != nil {
+			fmt.Printf("Error creating request handler: %v", err)
+			return datatypes.ComparisonMetrics{}, err
+		}
 
-	apiTokenField = fmt.Sprintf("Api-Token %v", ps.APIToken)
-	req.Header.Add("Authorization", apiTokenField)
+		apiTokenField = fmt.Sprintf("Api-Token %v", ps.APIToken)
+		req.Header.Add("Authorization", apiTokenField)
 
-	// Perform the request
-	r, err = client.Do(req)
-	if err != nil {
-		fmt.Printf("Error reading metric data from Dynatrace: %v", err)
-		return datatypes.ComparisonMetrics{}, err
-	}
-	// Check the status code
-	if r.StatusCode != 200 {
-		fmt.Printf("Invalid status code from Dynatrace: %v.\n", r.StatusCode)
-		return datatypes.ComparisonMetrics{}, fmt.Errorf("Invalid status code from Dynatrace: %v", r.StatusCode)
-	}
+		// Perform the request
+		r, err = client.Do(req)
+		if err != nil {
+			fmt.Printf("Error reading metric data from Dynatrace: %v", err)
+			return datatypes.ComparisonMetrics{}, err
+		}
+		// Check the status code
+		if r.StatusCode != 200 {
+			fmt.Printf("Invalid status code from Dynatrace: %v.\n", r.StatusCode)
+			return datatypes.ComparisonMetrics{}, fmt.Errorf("Invalid status code from Dynatrace: %v", r.StatusCode)
+		}
 
-	// Read in the body
-	b, err = ioutil.ReadAll(r.Body)
-	defer r.Body.Close()
+		// Read in the body
+		b, err = ioutil.ReadAll(r.Body)
+		defer r.Body.Close()
 
-	// Try to parse the response into MetricsResponses
-	var previousMetricsResponse datatypes.DynatraceMetricsResponse
-	err = json.Unmarshal(b, &previousMetricsResponse)
-	if err != nil {
-		return datatypes.ComparisonMetrics{}, err
-	}
-	numberOfMetrics = len(previousMetricsResponse.Metrics.BuiltinServiceErrorsTotalRate.MetricValues)
-	if numberOfMetrics < 1 {
-		return datatypes.ComparisonMetrics{}, fmt.Errorf("There were no Error Rate data points found in the previous event metrics: %v", spew.Sdump(previousMetricsResponse.Metrics))
-	}
-	numberOfMetrics = len(previousMetricsResponse.Metrics.BuiltinServiceResponseTime.MetricValues)
-	if numberOfMetrics < 1 {
-		return datatypes.ComparisonMetrics{}, fmt.Errorf("There were no Response Time data points found in the previous event metrics: %v", spew.Sdump(previousMetricsResponse.Metrics))
-	}
+		// Try to parse the response into MetricsResponses
+		var previousMetricsResponse datatypes.DynatraceMetricsResponse
+		err = json.Unmarshal(b, &previousMetricsResponse)
+		if err != nil {
+			return datatypes.ComparisonMetrics{}, err
+		}
+		numberOfMetrics = len(previousMetricsResponse.Metrics.BuiltinServiceErrorsTotalRate.MetricValues)
+		if numberOfMetrics < 1 {
+			return datatypes.ComparisonMetrics{}, fmt.Errorf("There were no Error Rate data points found in the previous event metrics: %v", spew.Sdump(previousMetricsResponse.Metrics))
+		}
+		numberOfMetrics = len(previousMetricsResponse.Metrics.BuiltinServiceResponseTime.MetricValues)
+		if numberOfMetrics < 1 {
+			return datatypes.ComparisonMetrics{}, fmt.Errorf("There were no Response Time data points found in the previous event metrics: %v", spew.Sdump(previousMetricsResponse.Metrics))
+		}
 
-	var bothMetricSets = datatypes.ComparisonMetrics{
-		CurrentMetrics:  currentMetricsResponse.Metrics,
-		PreviousMetrics: previousMetricsResponse.Metrics,
+		var bothMetricSets = datatypes.ComparisonMetrics{
+			CurrentMetrics:  currentMetricsResponse.Metrics,
+			PreviousMetrics: previousMetricsResponse.Metrics,
+		}
+		return bothMetricSets, nil
 	}
-
-	return bothMetricSets, nil
+	return metrics, nil
 }
 
 // CompareMetrics compares the metrics from the current and previous timeframe
 func CompareMetrics(metrics datatypes.ComparisonMetrics) (string, error) {
+	currErrRate := metrics.CurrentMetrics.BuiltinServiceErrorsTotalRate.MetricValues[0].Value
+	prevErrRate := metrics.PreviousMetrics.BuiltinServiceErrorsTotalRate.MetricValues[0].Value
+	errorRateDelta := currErrRate - prevErrRate
+	// fmt.Printf("Error rate: %v, from %v to %v.\n", errorRateDelta, prevErrRate, currErrRate)
+
+	if errorRateDelta > 0 {
+		errorMessage := fmt.Sprintf("The Error Rate increased since the previous test by %v, from %v to %v", errorRateDelta, prevErrRate, currErrRate)
+		return errorMessage, fmt.Errorf("Error rate increase of %v%%", errorRateDelta)
+	}
+
+	currResTime := metrics.CurrentMetrics.BuiltinServiceResponseTime.MetricValues[0].Value
+	prevResTime := metrics.PreviousMetrics.BuiltinServiceResponseTime.MetricValues[0].Value
+	responseTimeDelta := (currResTime - prevResTime) / 1000
+	// fmt.Printf("RT: %v, from %v to %v.\n", responseTimeDelta, prevResTime, currResTime)
+
+	if responseTimeDelta > 0 {
+		rtMessage := fmt.Sprintf("The Response Time increased since the previous test by %v, from %v to %v", responseTimeDelta, prevResTime, currResTime)
+		return rtMessage, fmt.Errorf("Response time increase of %vms", responseTimeDelta)
+	}
+
+	successResponse := fmt.Sprintf("Successful deploy! RT decreased by %vms and error rate decreased by %v%%.\n", math.Abs(responseTimeDelta), errorRateDelta)
+	return successResponse, nil
+}
+
+// CheckStaticThreshold compares the metrics from the current and previous timeframe
+func CheckStaticThreshold(metrics datatypes.ComparisonMetrics) (string, error) {
 	currErrRate := metrics.CurrentMetrics.BuiltinServiceErrorsTotalRate.MetricValues[0].Value
 	prevErrRate := metrics.PreviousMetrics.BuiltinServiceErrorsTotalRate.MetricValues[0].Value
 	errorRateDelta := currErrRate - prevErrRate

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -137,6 +137,8 @@ func GetMetrics(config datatypes.Config, ps datatypes.PerformanceSignature, ts [
 			CurrentMetrics:  currentMetricsResponse.Metrics,
 			PreviousMetrics: previousMetricsResponse.Metrics,
 		}
+
+		// fmt.Println(spew.Sdump(bothMetricSets))
 		return bothMetricSets, nil
 	}
 	return metrics, nil

--- a/performancesignature/performancesignature.go
+++ b/performancesignature/performancesignature.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"barrebre/goDynaPerfSignature/datatypes"
 	"barrebre/goDynaPerfSignature/deployments"
@@ -20,6 +21,7 @@ func ProcessRequest(w http.ResponseWriter, r *http.Request, config datatypes.Con
 	if err != nil {
 		return "", 400, err
 	}
+	// fmt.Printf("Received params: %v\n", spew.Sdump(performanceSignature))
 
 	// Verify all necessary params were sent
 	err = checkParams(performanceSignature)
@@ -29,13 +31,21 @@ func ProcessRequest(w http.ResponseWriter, r *http.Request, config datatypes.Con
 	}
 
 	// Query Dt for events
-	timestamps, err := deployments.GetDeploymentTimestamps(config, performanceSignature.ServiceID, performanceSignature.APIToken)
+	timestamps, err := deployments.GetDeploymentTimestamps(config, performanceSignature)
 	if err != nil {
 		fmt.Printf("Encountered error gathering event timestamps: %v\n", err)
 		return "", 503, fmt.Errorf("Encountered error gathering timestamps: %v", err)
 	}
-	if len(timestamps) < 2 {
-		return fmt.Sprintln("There were not enough deployment events on the service to test."), 200, nil
+
+	// Print out the deployment event(s) we found
+	currentStartPretty := time.Unix(timestamps[0].StartTime/1000, 000)
+	currentEndPretty := time.Unix(timestamps[0].EndTime/1000, 000)
+	if len(timestamps) == 1 {
+		fmt.Printf("Found current deployment from %v to %v.\n", currentStartPretty, currentEndPretty)
+	} else if len(timestamps) == 2 {
+		previousStartPretty := time.Unix(timestamps[1].StartTime/1000, 000)
+		previousEndPretty := time.Unix(timestamps[1].EndTime/1000, 000)
+		fmt.Printf("Found previous deployment from %v to %v and current deployment from %v to %v.\n", previousStartPretty, previousEndPretty, currentStartPretty, currentEndPretty)
 	}
 
 	metricsResponse, err := metrics.GetMetrics(config, performanceSignature, timestamps)
@@ -44,28 +54,42 @@ func ProcessRequest(w http.ResponseWriter, r *http.Request, config datatypes.Con
 		return "", 503, fmt.Errorf("Encountered error gathering metrics: %v", err)
 	}
 
-	successText, err := metrics.CompareMetrics(metricsResponse)
-	if err != nil {
-		responseText := fmt.Sprintf("Metric degradation found: %v\n", err)
-		fmt.Printf(responseText)
-		return "", 406, fmt.Errorf(responseText)
+	successText := ""
+	for _, metric := range performanceSignature.Metrics {
+		switch checkCounts := metric.Validation; checkCounts {
+		case "static":
+			response, err := metrics.CheckStaticThreshold(metricsResponse)
+			if err != nil {
+				degradationText := fmt.Sprintf("Metric degradation found: %v\n", err)
+				fmt.Printf(degradationText)
+				return "", 406, fmt.Errorf(degradationText)
+			}
+			successText += response
+		default:
+			response, err := metrics.CompareMetrics(metricsResponse)
+			if err != nil {
+				degradationText := fmt.Sprintf("Metric degradation found: %v\n", err)
+				fmt.Printf(degradationText)
+				return "", 406, fmt.Errorf(degradationText)
+			}
+			successText += response
+		}
 	}
-
 	return successText, 0, nil
 }
 
-// Check the body params sent in with the request to ensure we have all the data we need to query Dt
+// Check the required body params sent in with the request to ensure we have all the data we need to query Dt
 func checkParams(p datatypes.PerformanceSignature) error {
 	if p.APIToken == "" {
 		return fmt.Errorf("No API Token found in object: %v", spew.Sdump(p))
 	}
 
-	if len(p.MetricIDs) == 0 {
+	if len(p.Metrics) == 0 {
 		return fmt.Errorf("No MetricIDs found in object: %v", spew.Sdump(p))
 	}
 
-	if p.APIToken == "" {
-		return fmt.Errorf("No APIToken found in object: %v", spew.Sdump(p))
+	if p.ServiceID == "" {
+		return fmt.Errorf("No Services found in object: %v", spew.Sdump(p))
 	}
 
 	return nil


### PR DESCRIPTION
This update allows you to use any metric (instead of just Response Time and Error Rate) and allows you to use static thresholds instead of just comparison checks.