### PR TITLE
Streamlined the return parameters

### DIFF
--- a/datatypes/performancesignature.go
+++ b/datatypes/performancesignature.go
@@ -15,9 +15,9 @@ type PerformanceSignature struct {
 
 // PerformanceSignatureReturn defines the spec for what needs to be returned to the requester
 type PerformanceSignatureReturn struct {
-	ErrorCode int
-	Error     string
-	Response  []string
+	Error    bool
+	Pass     bool
+	Response []string
 }
 
 //// Example Values
@@ -76,15 +76,14 @@ var (
 	}
 
 	validPerformanceSignatureReturnSuccess = PerformanceSignatureReturn{
-		ErrorCode: 0,
-		Error:     "",
-		Response:  []string{"PASS - builtin:service.response.time:avg improvement to 82122.06 from 150879.00. (Difference: -68756.94)"},
+		Error:    false,
+		Pass:     true,
+		Response: []string{"PASS - builtin:service.response.time:avg improvement to 82122.06 from 150879.00. (Difference: -68756.94)"},
 	}
 
 	validPerformanceSignatureReturnFailure = PerformanceSignatureReturn{
-		ErrorCode: 406,
-		Error:     "Metric degradation found: ",
-		Response:  []string{},
+		Pass:     false,
+		Response: []string{"Metric degradation found: "},
 	}
 )
 

--- a/main.go
+++ b/main.go
@@ -34,9 +34,8 @@ func main() {
 		if err != nil {
 			logging.LogError(datatypes.Logging{Message: fmt.Sprintf("Couldn't parse the body of the request. Error was: %v.", err.Error())})
 			response := datatypes.PerformanceSignatureReturn{
-				ErrorCode: 400,
-				Error:     err.Error(),
-				Response:  []string{"Couldn't parse the body of the request"},
+				Error:    true,
+				Response: []string{"Couldn't parse the body of the request"},
 			}
 			utils.WriteResponse(w, response, datatypes.PerformanceSignature{})
 			return
@@ -47,9 +46,8 @@ func main() {
 		if err != nil {
 			logging.LogError(datatypes.Logging{Message: fmt.Sprintf("Could not ReadAndValidateParams. Error was: %v.", err.Error())})
 			response := datatypes.PerformanceSignatureReturn{
-				ErrorCode: 400,
-				Error:     err.Error(),
-				Response:  []string{"Could not read or validate given parameters"},
+				Error:    true,
+				Response: []string{"Could not read or validate given parameters"},
 			}
 			utils.WriteResponse(w, response, datatypes.PerformanceSignature{})
 			return

--- a/performancesignature/performancesignature_test.go
+++ b/performancesignature/performancesignature_test.go
@@ -59,66 +59,60 @@ func TestBuildDeploymentRequest(t *testing.T) {
 
 func TestCheckPerfSignature(t *testing.T) {
 	type testDefs struct {
-		Name            string
-		PerfSignature   datatypes.PerformanceSignature
-		MetricsResponse datatypes.ComparisonMetrics
-		ExpectPass      bool
-		ExpectedError   string
+		Name             string
+		PerfSignature    datatypes.PerformanceSignature
+		MetricsResponse  datatypes.ComparisonMetrics
+		ExpectedResponse []string
 	}
 
 	tests := []testDefs{
 		{
-			Name:            "Valid Default Check Failing Data",
-			PerfSignature:   datatypes.GetValidDefaultPerformanceSignature(),
-			MetricsResponse: datatypes.GetValidFailingComparisonMetrics(),
-			ExpectPass:      false,
-			ExpectedError:   "Metric degradation found: FAIL - dummy_metric_name:avg had a degradation of 0.88, from 1234.12 to 1235.00",
+			Name:             "Valid Default Check Failing Data",
+			PerfSignature:    datatypes.GetValidDefaultPerformanceSignature(),
+			MetricsResponse:  datatypes.GetValidFailingComparisonMetrics(),
+			ExpectedResponse: []string{"Metric degradation found: FAIL - dummy_metric_name:avg had a degradation of 0.88, from 1234.12 to 1235.00"},
 		},
 		{
-			Name:            "Valid Relative Check Failing Data",
-			PerfSignature:   datatypes.GetValidSmallRelativePerformanceSignature(),
-			MetricsResponse: datatypes.GetValidFailingComparisonMetrics(),
-			ExpectPass:      false,
-			ExpectedError:   "Metric degradation found: FAIL - dummy_metric_name:avg did not meet the relative threshold criteria. the current performance is 1235.00, which is not better than the previous value of 1234.12 plus the relative threshold of 0.00.",
+			Name:             "Valid Relative Check Failing Data",
+			PerfSignature:    datatypes.GetValidSmallRelativePerformanceSignature(),
+			MetricsResponse:  datatypes.GetValidFailingComparisonMetrics(),
+			ExpectedResponse: []string{"Metric degradation found: FAIL - dummy_metric_name:avg did not meet the relative threshold criteria. the current performance is 1235.00, which is not better than the previous value of 1234.12 plus the relative threshold of 0.00."},
 		},
 		{
-			Name:            "Valid Relative Check Passing Data",
-			PerfSignature:   datatypes.GetValidLargeRelativePerformanceSignature(),
-			MetricsResponse: datatypes.GetValidPassingComparisonMetrics(),
-			ExpectPass:      true,
+			Name:             "Valid Relative Check Passing Data",
+			PerfSignature:    datatypes.GetValidLargeRelativePerformanceSignature(),
+			MetricsResponse:  datatypes.GetValidPassingComparisonMetrics(),
+			ExpectedResponse: []string{"PASS - dummy_metric_name:avg improvement to 1234.12 from 1235.00. (Difference: -0.88)"},
 		},
 		{
-			Name:            "Valid Static Check Failing Data",
-			PerfSignature:   datatypes.GetValidStaticPerformanceSignature(),
-			MetricsResponse: datatypes.GetValidFailingComparisonMetrics(),
-			ExpectPass:      false,
-			ExpectedError:   "Metric degradation found: FAIL - dummy_metric_name:percentile(90) was above the static threshold: 1235.00, instead of a desired 1234.12",
+			Name:             "Valid Static Check Failing Data",
+			PerfSignature:    datatypes.GetValidStaticPerformanceSignature(),
+			MetricsResponse:  datatypes.GetValidFailingComparisonMetrics(),
+			ExpectedResponse: []string{"Metric degradation found: FAIL - dummy_metric_name:percentile(90) was above the static threshold: 1235.00, instead of a desired 1234.12"},
 		},
 		{
-			Name:            "Valid Default Check Passing Data",
-			PerfSignature:   datatypes.GetValidDefaultPerformanceSignature(),
-			MetricsResponse: datatypes.GetValidPassingComparisonMetrics(),
-			ExpectPass:      true,
+			Name:             "Valid Default Check Passing Data",
+			PerfSignature:    datatypes.GetValidDefaultPerformanceSignature(),
+			MetricsResponse:  datatypes.GetValidPassingComparisonMetrics(),
+			ExpectedResponse: []string{"PASS - Successful deploy! Improvement of 0.88, from 1235.00 to 1234.12"},
 		},
 		{
-			Name:            "No Data Returned",
-			PerfSignature:   datatypes.GetValidStaticPerformanceSignature(),
-			MetricsResponse: datatypes.GetMissingComparisonMetrics(),
-			ExpectPass:      false,
-			ExpectedError:   "there were no current metrics found for dummy_metric_name:percentile(90)",
+			Name:             "No Data Returned",
+			PerfSignature:    datatypes.GetValidStaticPerformanceSignature(),
+			MetricsResponse:  datatypes.GetMissingComparisonMetrics(),
+			ExpectedResponse: []string{"there were no current metrics found for dummy_metric_name:percentile(90)"},
 		},
 		{
-			Name:            "No Previous Deployment Data Returned - Default Check",
-			PerfSignature:   datatypes.GetValidDefaultPerformanceSignature(),
-			MetricsResponse: datatypes.GetMissingPreviousComparisonMetrics(),
-			ExpectPass:      false,
-			ExpectedError:   "no previous metrics to compare against for metric dummy_metric_name:avg",
+			Name:             "No Previous Deployment Data Returned - Default Check",
+			PerfSignature:    datatypes.GetValidDefaultPerformanceSignature(),
+			MetricsResponse:  datatypes.GetMissingPreviousComparisonMetrics(),
+			ExpectedResponse: []string{"No previous metrics to compare against for metric dummy_metric_name:avg"},
 		},
 		{
-			Name:            "No Previous Deployment Data Returned - Static Check",
-			PerfSignature:   datatypes.GetValidStaticPerformanceSignature(),
-			MetricsResponse: datatypes.GetMissingPreviousComparisonMetrics(),
-			ExpectPass:      true,
+			Name:             "No Previous Deployment Data Returned - Static Check",
+			PerfSignature:    datatypes.GetValidStaticPerformanceSignature(),
+			MetricsResponse:  datatypes.GetMissingPreviousComparisonMetrics(),
+			ExpectedResponse: []string{"PASS - dummy_metric_name:percentile(90) fit static threshold of 1234.12 with value 0.00."},
 		},
 	}
 
@@ -126,11 +120,7 @@ func TestCheckPerfSignature(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			response := checkPerfSignature(test.PerfSignature, test.MetricsResponse)
 
-			if test.ExpectPass == true {
-				assert.Equal(t, "", response.Error)
-			} else {
-				assert.Equal(t, response.Error, test.ExpectedError)
-			}
+			assert.Equal(t, test.ExpectedResponse, response.Response)
 		})
 	}
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -10,7 +10,7 @@ import (
 	"github.com/barrebre/goDynaPerfSignature/logging"
 )
 
-const version = "1.5.0"
+const version = "1.6.0"
 
 // GetConfig retrives the config from the env
 // TODO: optimize this in the future so it doesn't check the getenv each time

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -63,8 +63,10 @@ func GetAppVersion() string {
 // WriteResponse helps respond to requests
 func WriteResponse(w http.ResponseWriter, response datatypes.PerformanceSignatureReturn, ps datatypes.PerformanceSignature) {
 	w.Header().Set("Content-Type", "application/json")
-	if response.ErrorCode != 0 {
-		w.WriteHeader(response.ErrorCode)
+	if response.Error {
+		w.WriteHeader(503)
+	} else if !response.Pass {
+		w.WriteHeader(406)
 	}
 
 	responseJson, err := json.Marshal(response)
@@ -76,9 +78,8 @@ func WriteResponse(w http.ResponseWriter, response datatypes.PerformanceSignatur
 
 		w.WriteHeader(513)
 		marshalErrorJson := datatypes.PerformanceSignatureReturn{
-			ErrorCode: 513,
-			Error:     fmt.Sprintf("goDynaPerfSignature internal problem sending the response. The message was supposed to be: %v", response.Response),
-			Response:  []string{},
+			Error:    true,
+			Response: []string{fmt.Sprintf("goDynaPerfSignature internal problem sending the response. The message was supposed to be: %v", response.Response)},
 		}
 
 		errorJson, err2 := json.Marshal(marshalErrorJson)

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -82,7 +82,7 @@ func TestWriteResponse(t *testing.T) {
 	type testDefs struct {
 		Name                       string
 		ExpectedCode               int
-		ExpectedReturnError        string
+		ExpectedResponse           []string
 		PerformanceSignatureReturn datatypes.PerformanceSignatureReturn
 	}
 
@@ -90,13 +90,13 @@ func TestWriteResponse(t *testing.T) {
 		{
 			Name:                       "Successful deployment",
 			ExpectedCode:               200,
-			ExpectedReturnError:        "",
+			ExpectedResponse:           []string{"PASS - builtin:service.response.time:avg improvement to 82122.06 from 150879.00. (Difference: -68756.94)"},
 			PerformanceSignatureReturn: datatypes.GetValidPerformanceSignatureReturnSuccess(),
 		},
 		{
 			Name:                       "Failure deployment",
 			ExpectedCode:               406,
-			ExpectedReturnError:        "Metric degradation found: ",
+			ExpectedResponse:           []string{"Metric degradation found: "},
 			PerformanceSignatureReturn: datatypes.GetValidPerformanceSignatureReturnFailure(),
 		},
 	}
@@ -113,9 +113,7 @@ func TestWriteResponse(t *testing.T) {
 			json.Unmarshal(body, &responseBody)
 
 			assert.Equal(t, test.ExpectedCode, resp.StatusCode)
-			if test.ExpectedReturnError != "" {
-				assert.Equal(t, test.ExpectedReturnError, responseBody.Error)
-			}
+			assert.Equal(t, test.ExpectedResponse, responseBody.Response)
 
 		})
 	}


### PR DESCRIPTION
Instead of returning an arbitrary errorcode, the app now returns three params:
* Error: Was there an error processing the request. This could be reading from Dynatrace, building requests, or parsing returned data
* Pass: Was this a successful deployment
* Response: Whether there was an error, a pass, or a fail, the Response will describe the reasoning

Also, the app is now updated so that all checks will run for all requested metrics, even if a preceeding request fails. For example, if both response time and error rate are to be checked, the error rate check will still be evaluated even if the response time check fails. This is so that a team can know "yes, we didn't meet our response time SLA, but we still did meet our error budget"